### PR TITLE
Fixed clearCookies function for WkWebView

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
     
     <!-- android -->
     <platform name="android">
-        <config-file target="app/src/mainAndroidManifest.xml" parent="/manifest">
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
     
     <!-- android -->
     <platform name="android">
-        <config-file target="AndroidManifest.xml" parent="/manifest">
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
     
     <!-- android -->
     <platform name="android">
-        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
+        <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
     
     <!-- android -->
     <platform name="android">
-        <config-file target="AndroidManifest.xml" parent="/manifest">
+        <config-file target="app/src/mainAndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         </config-file>

--- a/src/ios/CDVCookieMaster.m
+++ b/src/ios/CDVCookieMaster.m
@@ -87,7 +87,7 @@
 - (void)clearCookies:(CDVInvokedUrlCommand*)command
 {
     if ([self.webView isKindOfClass:[WKWebView class]]) {
-        if (@available(iOS 11.0, *)) {
+        if (@available(iOS 9.0, *)) {
             NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
             NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
             [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
@@ -96,7 +96,7 @@
                                                         NSLog(@"Cookies Cleared");
                                                     }];
         } else {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 11+ in order to clear the cookie"];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 9+ in order to clear the cookie"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             return;
         }

--- a/src/ios/CDVCookieMaster.m
+++ b/src/ios/CDVCookieMaster.m
@@ -86,31 +86,28 @@
 
 - (void)clearCookies:(CDVInvokedUrlCommand*)command
 {
+    CDVPluginResult* pluginResult = nil;
+    
     if ([self.webView isKindOfClass:[WKWebView class]]) {
-        if (@available(iOS 9.0, *)) {
+        if (@available(iOS 11.0, *)) {
             NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
             NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
-            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
-                                                    modifiedSince:dateFrom
-                                                    completionHandler:^{
-                                                        NSLog(@"Cookies Cleared");
-                                                    }];
+            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes modifiedSince:dateFrom completionHandler:^{ NSLog(@"Cookies Cleared"); }];
         } else {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 9+ in order to clear cookies"];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 11+ in order to clear cookies"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             return;
         }
     } else {
         NSHTTPCookie *cookie;
-           NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-           for (cookie in [storage cookies]) {
-               [storage deleteCookie:cookie];
-           }
+        NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+        for (cookie in [storage cookies]) {
+            [storage deleteCookie:cookie];
+        }
+        [[NSUserDefaults standardUserDefaults] synchronize];
     }
 
-    [[NSUserDefaults standardUserDefaults] synchronize];
-
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 

--- a/src/ios/CDVCookieMaster.m
+++ b/src/ios/CDVCookieMaster.m
@@ -71,11 +71,22 @@
 
 - (void)clearCookies:(CDVInvokedUrlCommand*)command
 {
-    NSHTTPCookie *cookie;
-    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    for (cookie in [storage cookies]) {
-        [storage deleteCookie:cookie];
+    if (@available(iOS 11.0, *)) {
+        NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
+        NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
+        [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
+                                                modifiedSince:dateFrom
+                                                completionHandler:^{
+                                                    NSLog(@"Cookies Cleared");
+                                                }];
+    } else {
+        NSHTTPCookie *cookie;
+           NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+           for (cookie in [storage cookies]) {
+               [storage deleteCookie:cookie];
+           }
     }
+
     [[NSUserDefaults standardUserDefaults] synchronize];
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];

--- a/src/ios/CDVCookieMaster.m
+++ b/src/ios/CDVCookieMaster.m
@@ -7,6 +7,7 @@
 //
 
 #import "CDVCookieMaster.h"
+#import <WebKit/WebKit.h>
 
 
 @implementation CDVCookieMaster
@@ -44,8 +45,6 @@
 
  - (void)setCookieValue:(CDVInvokedUrlCommand*)command
 {
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
-
     CDVPluginResult* pluginResult = nil;
     NSString* urlString = [command.arguments objectAtIndex:0];
     NSString* cookieName = [command.arguments objectAtIndex:1];
@@ -58,12 +57,28 @@
     [cookieProperties setObject:@"/" forKey:NSHTTPCookiePath];
 
     NSHTTPCookie *cookie = [NSHTTPCookie cookieWithProperties:cookieProperties];
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:cookie];
 
-    NSArray* cookies = [NSArray arrayWithObjects:cookie, nil];
+    if ([self.webView isKindOfClass:[WKWebView class]]) {
+        WKWebView* wkWebView = (WKWebView*) self.webView;
 
-    NSURL *url = [[NSURL alloc] initWithString:urlString];
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:url mainDocumentURL:nil];
+        if (@available(iOS 11.0, *)) {
+            [wkWebView.configuration.websiteDataStore.httpCookieStore setCookie:cookie completionHandler:^{NSLog(@"Cookie set in WKWebView");}];
+        } else {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 11+ in order to set the cookie"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+
+            return;
+        }
+    } else {
+        [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
+
+        [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:cookie];
+
+        NSArray* cookies = [NSArray arrayWithObjects:cookie, nil];
+
+        NSURL *url = [[NSURL alloc] initWithString:urlString];
+        [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:url mainDocumentURL:nil];
+    }
 
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Set cookie executed"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -71,14 +86,20 @@
 
 - (void)clearCookies:(CDVInvokedUrlCommand*)command
 {
-    if (@available(iOS 11.0, *)) {
-        NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
-        NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
-        [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
-                                                modifiedSince:dateFrom
-                                                completionHandler:^{
-                                                    NSLog(@"Cookies Cleared");
-                                                }];
+    if ([self.webView isKindOfClass:[WKWebView class]]) {
+        if (@available(iOS 11.0, *)) {
+            NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
+            NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
+            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
+                                                    modifiedSince:dateFrom
+                                                    completionHandler:^{
+                                                        NSLog(@"Cookies Cleared");
+                                                    }];
+        } else {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 11+ in order to clear the cookie"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            return;
+        }
     } else {
         NSHTTPCookie *cookie;
            NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];

--- a/src/ios/CDVCookieMaster.m
+++ b/src/ios/CDVCookieMaster.m
@@ -96,7 +96,7 @@
                                                         NSLog(@"Cookies Cleared");
                                                     }];
         } else {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 9+ in order to clear the cookie"];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"WKWebView requires iOS 9+ in order to clear cookies"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             return;
         }


### PR DESCRIPTION
This is using the proper method to clear the cookies when you are using WkWebview and have iOS 11 or above.
Plus it will maintain compatibility for lower version of iOS using the legacy method.